### PR TITLE
Fix `error: The source specified has already been added to the list of available package sources. Provide a unique source.`

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,16 +23,22 @@ class Action {
         this.includeSymbols = JSON.parse(process.env.INPUT_INCLUDE_SYMBOLS || process.env.INCLUDE_SYMBOLS)
         this.throwOnVersionExixts = process.env.INPUT_THOW_ERROR_IF_VERSION_EXISTS || process.env.THOW_ERROR_IF_VERSION_EXISTS
 
-        let addSourceCmd;
-        if (this.nugetSource.startsWith(`https://nuget.pkg.github.com/`)) {
-            this.sourceType = "GPR"
-            addSourceCmd = `dotnet nuget add source ${this.nugetSource}/index.json --name=${(SOURCE_NAME)} --username=${this.githubUser} --password=${this.nugetKey} --store-password-in-clear-text`
-        } else {
-            this.sourceType = "NuGet"
-            addSourceCmd = `dotnet nuget add source ${this.nugetSource}/v3/index.json --name=${SOURCE_NAME}`
-        }
+        const existingSources = this._executeCommand("dotnet nuget list source", { encoding: "utf8" }).stdout;
+        if(existingSources.includes(this.nugetSource) === false) {
+            let addSourceCmd;
+            if (this.nugetSource.startsWith(`https://nuget.pkg.github.com/`)) {
+                this.sourceType = "GPR"
+                addSourceCmd = `dotnet nuget add source ${this.nugetSource}/index.json --name=${(SOURCE_NAME)} --username=${this.githubUser} --password=${this.nugetKey} --store-password-in-clear-text`
+            } else {
+                this.sourceType = "NuGet"
+                addSourceCmd = `dotnet nuget add source ${this.nugetSource}/v3/index.json --name=${SOURCE_NAME}`
+            }
 
-        console.log(this._executeCommand(addSourceCmd, { encoding: "utf-8" }).stdout)
+            console.log(this._executeCommand(addSourceCmd, { encoding: "utf-8" }).stdout)
+        } else {
+            console.log(this.nugetSource + " is already in sources.")
+        }
+        
         const list1 = this._executeCommand("dotnet nuget list source", { encoding: "utf8" }).stdout;
         const enable = this._executeCommand(`dotnet nuget enable source ${SOURCE_NAME}`, { encoding: "utf8" }).stdout;
         console.log(list1);


### PR DESCRIPTION
Skip adding nugetSource, if it is already there.

Hi @Rebel028 , Can you please review this and let me know if it's OK to merge?

Detailed error resolved by this PR.

```
Usage: dotnet nuget enable source [arguments] [options]

Arguments:
  name  Name of the source.

Options:
  --configfile  The NuGet configuration file. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used. For more information, see https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior.
  -h|--help     Show help information

Project Filepath: ***/***.csproj
Version Filepath: ***/***.csproj
Version Regex: /^\s*<Version>(.*)<\/Version>\s*$/m
Version: 0.0.1
Package Name: ***
This is GPR, changing url for versioning...
https://nuget.pkg.github.com/***/download/***/index.json
Status code: 401: Unauthorized
Error: 😭 error: 401: Unauthorized
/home/runner/work/_actions/Rebel028/publish-nuget/v2.6.0/index.js:44
        throw new Error(msg)
        ^

Error: error: 401: Unauthorized
    at Action._printErrorAndExit (/home/runner/work/_actions/Rebel028/publish-nuget/v2.6.0/index.js:44:15)
    at ClientRequest.<anonymous> (/home/runner/work/_actions/Rebel028/publish-nuget/v2.6.0/index.js:165:21)
    at Object.onceWrapper (events.js:300:26)
    at ClientRequest.emit (events.js:210:5)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:583:27)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:115:17)
    at TLSSocket.socketOnData (_http_client.js:456:22)
    at TLSSocket.emit (events.js:210:5)
    at addChunk (_stream_readable.js:309:12)
    at readableAddChunk (_stream_readable.js:290:11)
```