### PR TITLE
Fix issue with boolean string always resolving to true

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ class Action {
         this.nugetKey = process.env.INPUT_NUGET_KEY || process.env.NUGET_KEY
         this.nugetSource = process.env.INPUT_NUGET_SOURCE || process.env.NUGET_SOURCE
         this.includeSymbols = JSON.parse(process.env.INPUT_INCLUDE_SYMBOLS || process.env.INCLUDE_SYMBOLS)
-        this.throwOnVersionExixts = process.env.INPUT_THOW_ERROR_IF_VERSION_EXISTS || process.env.THOW_ERROR_IF_VERSION_EXISTS
+        this.throwOnVersionExixts = JSON.parse(process.env.INPUT_THOW_ERROR_IF_VERSION_EXISTS || process.env.THOW_ERROR_IF_VERSION_EXISTS)
 
         const existingSources = this._executeCommand("dotnet nuget list source", { encoding: "utf8" }).stdout;
         if(existingSources.includes(this.nugetSource) === false) {


### PR DESCRIPTION
`THOW_ERROR_IF_VERSION_EXISTS` will always be a string. So any conditionals on that field will always assert to `true` - even if the value of that env is `false`.

This copies the convention from the other booleans to wrap that in a `JSON.parse`