### PR TITLE
Fix several errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
     name: build, pack & publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       # - name: Setup dotnet
       #   uses: actions/setup-dotnet@v1


### PR DESCRIPTION
`actions/checkout@v2` is necessary because with `v1`, pushing the newly created tag failed with `fatal: could not read Username for 'https://github.com': No such device or address`.

The default source name should be `nuget.org` because `https://api.nuget.org/v3/index.json` seems to be available by default under the name `nuget.org`. Previously, the code checked whether the provided source (default `api.nuget.org`) was in existing sources, and if it was, assumed that it was under the name `default`, which didn't work.

`options` has to be initialized to `{ }` because `https.get` fails silently otherwise, which is what was happening in the non-GPR case.

URL logging should happen for both GPR and non-GPR.