### PR TITLE
Updated --no-symbols syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ class Action {
         const packages = fs.readdirSync(".").filter(fn => fn.endsWith("nupkg"))
         console.log(`Generated Package(s): ${packages.join(", ")}`)
 
-        const pushCmd = `dotnet nuget push *.nupkg -s ${(this.sourceName)} ${this.nugetSource !== "GPR"? `-k ${this.nugetKey}`: ""} --skip-duplicate ${!this.includeSymbols ? "-n 1" : ""}`
+        const pushCmd = `dotnet nuget push *.nupkg -s ${(this.sourceName)} ${this.nugetSource !== "GPR"? `-k ${this.nugetKey}`: ""} --skip-duplicate ${!this.includeSymbols ? "--no-symbols" : ""}`
 
         const pushOutput = this._executeCommand(pushCmd, { encoding: "utf-8" }).stdout
 


### PR DESCRIPTION
According to https://github.com/NuGet/NuGet.Client/pull/4326 there's no need to specify 1 or true after `--no-symbols` or `-n`. 

It's a breaking change, so the newer versions of nuget cli will throw error: File does not exist (true) after executig `dotnet nuget push` (example: https://github.com/NuGet/Home/issues/11601). The package is still pushed but the workflow using this action fails. 

This update is made to fix it, but it may result in backward compatibility issues with previous versions of nuget cli