### PR TITLE
Added PACK_NO_BUILD option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ NUGET_KEY | | API key to authenticate with NuGet server, or a token, issued for 
 NUGET_SOURCE | `https://api.nuget.org` | NuGet server uri hosting the packages, defaults to https://api.nuget.org
 INCLUDE_SYMBOLS | `false` | Flag to toggle pushing symbols along with nuget package to the server, disabled by default
 THOW_ERROR_IF_VERSION_EXISTS | `false` | Flag to throw an error when trying to publish an existing version of a package
+PACK_NO_BUILD | `true` | Adds the `--no-build` option to the `dotnet pack` command. Enabled by default.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
         description: Flag to throw an error when trying to publish an existing version of a package
         required: false
         default: false
+    PACK_NO_BUILD:
+        description: Adds the `--no-build` option to the `dotnet pack` command. Enabled by default.
+        required: false
+        default: true
 
 outputs:
     VERSION:

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ class Action {
         this.nugetSource = process.env.INPUT_NUGET_SOURCE || process.env.NUGET_SOURCE
         this.includeSymbols = JSON.parse(process.env.INPUT_INCLUDE_SYMBOLS || process.env.INCLUDE_SYMBOLS)
         this.throwOnVersionExixts = JSON.parse(process.env.INPUT_THOW_ERROR_IF_VERSION_EXISTS || process.env.THOW_ERROR_IF_VERSION_EXISTS)
+        this.pack_no_build = JSON.parse(process.env.INPUT_PACK_NO_BUILD || process.env.PACK_NO_BUILD);
 
         if (this.nugetSource.startsWith(`https://api.nuget.org`)) {
             this.sourceName = "nuget.org"
@@ -90,7 +91,8 @@ class Action {
         
         this._executeInProcess(`dotnet build -c Release ${this.projectFile}`)
 
-        this._executeInProcess(`dotnet pack ${this.includeSymbols ? "--include-symbols -p:SymbolPackageFormat=snupkg" : ""} --no-build -c Release ${this.projectFile} -o .`)
+        const noBuildOption = this.pack_no_build ? "--no-build": ""
+        this._executeInProcess(`dotnet pack ${this.includeSymbols ? "--include-symbols -p:SymbolPackageFormat=snupkg" : ""} ${noBuildOption} -c Release ${this.projectFile} -o .`)
 
         const packages = fs.readdirSync(".").filter(fn => fn.endsWith("nupkg"))
         console.log(`Generated Package(s): ${packages.join(", ")}`)


### PR DESCRIPTION
[For the solution in this scenario](https://stackoverflow.com/a/59893520/6393893), the "--no-build" option should not be in the packaging command. Because when "dotnet pack --no-build..." command is run, it will cause the error `"The 'NoBuild' property was set to true but the 'Build' target was invoked"`.